### PR TITLE
Fix Home breadcrumb URL

### DIFF
--- a/s3.js
+++ b/s3.js
@@ -54,7 +54,7 @@ function updateBreadcrumb(path) {
   const parts = path.split('/').filter((part) => part);
   let crumbPath = '';
 
-  breadcrumb.innerHTML = '<li class="breadcrumb-item"><a href="/">Home</a></li>';
+  breadcrumb.innerHTML = '<li class="breadcrumb-item"><a href="index.html">Home</a></li>';
 
   parts.forEach((part, index) => {
     crumbPath += part + '/';


### PR DESCRIPTION
99% of users do not have an ALB or CF in front of the S3 bucket with rule to redirect from root path to default index.html, thus path must be set to index.html by default.